### PR TITLE
Fixed snake eating itself on moving in the opposite direction

### DIFF
--- a/Snake.py
+++ b/Snake.py
@@ -17,7 +17,7 @@ class Snake:
         self.x = x
         self.y = y
         self.length = 1
-        self.body = []
+        self.body = [(x, y)]
         self.head_img = img
 
     def get_head(self):

--- a/main.py
+++ b/main.py
@@ -133,19 +133,19 @@ def gameLoop():
                 pyExit = True
 
             if event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_LEFT:
+                if event.key == pygame.K_LEFT and dirn != "right":
                     dirn = "left"
                     dx = -1
                     dy = 0
-                if event.key == pygame.K_RIGHT:
+                if event.key == pygame.K_RIGHT and dirn != "left":
                     dirn = "right"
                     dx = 1
                     dy = 0
-                if event.key == pygame.K_UP:
+                if event.key == pygame.K_UP and dirn != "down":
                     dirn = "up"
                     dy = -1
                     dx = 0
-                if event.key == pygame.K_DOWN:
+                if event.key == pygame.K_DOWN != dirn != "up":
                     dirn = "down"
                     dy = 1
                     dx = 0


### PR DESCRIPTION
Refer issue #19 

To fix this I compared the direction the user intends to go with the direction the snake is currently moving in if the directions are opposite then the direction won't be updated.